### PR TITLE
Remove prices from menu

### DIFF
--- a/views/partials/menu.ejs
+++ b/views/partials/menu.ejs
@@ -4,15 +4,14 @@
 
 		<!-- Food ==============================================================-->
 		<!-- BreakFast =========================================================-->
-		<div class="row expanded">
+		<div class="row">
 			<div class="small-12 large-6 columns menu-column">
 				<h3 class="menu-section-title">Breakfast</h3>
-				<p class="menu-info"><i>Breakfast served until 11:00 A.M.</i><br><br></p>
+				<p class="menu-info" id="breakfast-subtitle"><i>Breakfast served until 11:00 A.M.</i></p>
 
 				<div class="item">
 					<div class="item-row">
 						<span class="item-name">Scramble Flatbread</span>
-						<span class="price">5.99</span>
 					</div>
 					<div class="item-row">
 						<span class="sub-title">Scrambled eggs, tomato, red peppers, onion & cheddar cheese</span>
@@ -22,7 +21,6 @@
 				<div class="item">
 					<div class="item-row">
 						<span class="item-name">Breakfast Bagel</span>
-						<span class="price">5.95</span>
 					</div>
 					<div class="item-row">
 						<span class="sub-title">Eggs, ham or bacon & cheddar cheese</span>
@@ -32,7 +30,6 @@
 				<div class="item">
 					<div class="item-row">
 						<span class="item-name">Chorizo Burrito</span>
-						<span class="price">5.99</span>
 					</div>
 					<div class="item-row">
 						<span class="sub-title">Eggs, green peppers, black beans, onions, chorizo & mozzarella cheese</span>
@@ -42,21 +39,18 @@
 				<div class="item">
 					<div class="item-row">
 						<span class="item-name">Oatmeal</span>
-						<span class="price">3.99</span>
 					</div>
 					<div class="item-row">
 						<span class="sub-title">Served w/ milk and fruit</span>
 					</div>
 					<div class="item-row">
 						<span class="sub-title">Substitute yogurt or soy milk</span>
-						<span class="price">.50</span>
 					</div>
 				</div>
 
 				<div class="item">
 					<div class="item-row">
 						<span class="item-name">Toasted Bagel</span>
-						<span class="price">2.10</span>
 					</div>
 					<div class="item-row">
 						<span class="sub-title">Served with cream cheese and choice of jelly</span>
@@ -66,7 +60,6 @@
 				<div class="item">
 					<div class="item-row">
 						<span class="item-name">Granola</span>
-						<span class="price">3.50</span>
 					</div>
 					<div class="item-row">
 						<span class="sub-title">Served with choice of yogurt or milk</span>
@@ -86,7 +79,6 @@
 				<div class="item">
 					<div class="item-row">
 						<span class="item-name">Flatbread Sandwich</span>
-						<span class="price">7.50</span>
 					</div>
 					<div class="item-row">
 						<span class="sub-title">Ham, w/ melted provolone cheese & red peppers</span>
@@ -99,7 +91,6 @@
 				<div class="item">
 					<div class="item-row">
 						<span class="item-name">Avocado BLT</span>
-						<span class="price">7.25</span>
 					</div>
 					<div class="item-row">
 						<span class="sub-title">Smoked bacon, lettuce, tomato & avocado</span>
@@ -112,7 +103,6 @@
 				<div class="item">
 					<div class="item-row">
 						<span class="item-name">Turkey Avocado BLT</span>
-						<span class="price">7.95</span>
 					</div>
 					<div class="item-row">
 						<span class="sub-title">Roasted turkey, smoked bacon, avocado, lettuce & tomato</span>
@@ -125,7 +115,6 @@
 				<div class="item">
 					<div class="item-row">
 						<span class="item-name">Garden Sandwich</span>
-						<span class="price">6.25</span>
 					</div>
 					<div class="item-row">
 						<span class="sub-title">Lettuce, tomato, shredded carrots, roasted red pepper, red onions, avocado & mayo</span>
@@ -138,7 +127,6 @@
 				<div class="item">
 					<div class="item-row">
 						<span class="item-name">Ham or Turkey Swiss Croissant</span>
-						<span class="price">5.99</span>
 					</div>
 					<div class="item-row">
 						<span class="sub-title">Ham or turkey w/ melted swiss cheese</span>
@@ -148,7 +136,6 @@
 				<div class="item">
 					<div class="item-row">
 						<span class="item-name">Southwest Salad</span>
-						<span class="price">5.99</span>
 					</div>
 					<div class="item-row">
 						<span class="sub-title">Green lettuce, black beans, corn, tomatoes, red & green peppers, cheese, chicken & tortilla chips with spicy southwest dressing</span>
@@ -158,7 +145,6 @@
 				<div class="item">
 					<div class="item-row">
 						<span class="item-name">Bean Flatbread Quesadilla</span>
-						<span class="price">4.99</span>
 					</div>
 					<div class="item-row">
 						<span class="sub-title">Refried beans, mix peppers and cheese on flatbread</span>
@@ -168,7 +154,6 @@
 				<div class="item">
 					<div class="item-row">
 						<span class="item-name">Chicken Flatbread Quesadilla</span>
-						<span class="price">5.99</span>
 					</div>
 					<div class="item-row">
 						<span class="sub-title">Seasoned chicken and cheese on a flatbread</span>
@@ -187,21 +172,13 @@
 		</div>
 
 				<!-- Espresso =======================================================-->
-		<div class="row expanded">
-			<div class="small-12 large-6 columns menu-column">
+		<div class="row">
+			<div class="small-12 large-4 columns menu-column">
 				<h4 class="menu-sub-heading">Espresso</h4>
 
 				<div class="item">
 					<div class="item-row">
 						<span class="item-name">Espresso Shot</span>
-					</div>
-					<div class="item-row">
-						<span class="sub-title">1 shot</span>
-						<span class="price">2.10</span>
-					</div>
-					<div class="item-row">
-						<span class="sub-title">2 shots</span>
-						<span class="price">2.35</span>
 					</div>
 				</div>
 
@@ -212,14 +189,6 @@
 					<div class="item-row">
 						<span class="sub-title"><i>Espresso shot w/ a dash of milk</i></span>
 					</div>
-					<div class="item-row">
-						<span class="sub-title">1 shot</span>
-						<span class="price">2.25</span>
-					</div>
-					<div class="item-row">
-						<span class="sub-title">2 shots</span>
-						<span class="price">2.95</span>
-					</div>
 				</div>
 
 				<div class="item">
@@ -228,18 +197,6 @@
 					</div>
 					<div class="item-row">
 						<span class="sub-title"><i>Frothy milk poured through espresso</i></span>
-					</div>
-					<div class="item-row">
-						<span class="sub-title">small</span>
-						<span class="price">3.50</span>
-					</div>
-					<div class="item-row">
-						<span class="sub-title">medium</span>
-						<span class="price">3.75</span>
-					</div>
-					<div class="item-row">
-						<span class="sub-title">large</span>
-						<span class="price">4.50</span>
 					</div>
 				</div>
 
@@ -250,24 +207,11 @@
 					<div class="item-row">
 						<span class="sub-title"><i>Latte w/ chocolate syrup</i></span>
 					</div>
-					<div class="item-row">
-						<span class="sub-title">small</span>
-						<span class="price">3.75</span>
-					</div>
-					<div class="item-row">
-						<span class="sub-title">medium</span>
-						<span class="price">4.50</span>
-					</div>
-					<div class="item-row">
-						<span class="sub-title">large</span>
-						<span class="price">4.75</span>
-					</div>
 				</div>
 
 				<div class="item">
 					<div class="item-row">
 						<span class="item-name">Americano</span>
-						<span class="price">3.50</span>
 					</div>
 					<div class="item-row">
 						<span class="sub-title"><i>Espresso w/ hot water</i></span>
@@ -281,20 +225,11 @@
 					<div class="item-row">
 						<span class="sub-title"><i>Extra frothy milk poured into espresso</i></span>
 					</div>
-					<div class="item-row">
-						<span class="sub-title">small</span>
-						<span class="price">3.50</span>
-					</div>
-					<div class="item-row">
-						<span class="sub-title">medium</span>
-						<span class="price">3.75</span>
-					</div>
 				</div>
 
 				<div class="item">
 					<div class="item-row">
 						<span class="item-name">Conpana</span>
-						<span class="price">2.95</span>
 					</div>
 					<div class="item-row">
 						<span class="sub-title"><i>Espresso shot w/ whipped cream</i></span>
@@ -304,7 +239,6 @@
 				<div class="item">
 					<div class="item-row">
 						<span class="item-name">Cortado</span>
-						<span class="price">2.95</span>
 					</div>
 					<div class="item-row">
 						<span class="sub-title"><i>Equal parts espresso & steamed milk</i></span>
@@ -314,50 +248,12 @@
 			</div>
 
 		<!-- Coffee & Tea ======================================================-->
-			<div class="small-12 large-6 columns menu-column">
+			<div class="small-12 large-4 columns menu-column">
 				<h4 class="menu-sub-heading">Coffee & Tea</h4>
 
 				<div class="item">
 					<div class="item-row">
 						<span class="item-name">Coffee</span>
-						<span class="sub-title"><i>(in a mug)</i></span>
-					</div>
-					<div class="item-row">
-						<span class="sub-title">small</span>
-						<span class="price">1.70</span>
-					</div>
-					<div class="item-row">
-						<span class="sub-title">medium</span>
-						<span class="price">1.90</span>
-					</div>
-					<div class="item-row">
-						<span class="sub-title">large</span>
-						<span class="price">2.10</span>
-					</div>
-				</div>
-
-				<div class="item">
-					<div class="item-row">
-						<span class="item-name">Coffee To Go</span>
-					</div>
-					<div class="item-row">
-						<span class="sub-title">In a personal mug <i>(20oz maximum)</i></span>
-						<span class="price">1.90</span>
-					</div>
-					<div class="item-row">
-						<span class="sub-title">In a paper cup</span>
-					</div>
-					<div class="item-row">
-						<span class="sub-title">small</span>
-						<span class="price">1.90</span>
-					</div>
-					<div class="item-row">
-						<span class="sub-title">medium</span>
-						<span class="price">2.10</span>
-					</div>
-					<div class="item-row">
-						<span class="sub-title">large</span>
-						<span class="price">2.30</span>
 					</div>
 				</div>
 
@@ -368,35 +264,11 @@
 					<div class="item-row">
 						<span class="sub-title"><i>Chilled dark roasted brew</i></span>
 					</div>
-					<div class="item-row">
-						<span class="sub-title">small</span>
-						<span class="price">2.30</span>
-					</div>
-					<div class="item-row">
-						<span class="sub-title">medium</span>
-						<span class="price">2.55</span>
-					</div>
-					<div class="item-row">
-						<span class="sub-title">large</span>
-						<span class="price">2.80</span>
-					</div>
 				</div>
 
 				<div class="item">
 					<div class="item-row">
 						<span class="item-name">Masala Chai Latte</span>
-					</div>
-					<div class="item-row">
-						<span class="sub-title">small</span>
-						<span class="price">3.45</span>
-					</div>
-					<div class="item-row">
-						<span class="sub-title">medium</span>
-						<span class="price">3.95</span>
-					</div>
-					<div class="item-row">
-						<span class="sub-title">large</span>
-						<span class="price">4.25</span>
 					</div>
 				</div>
 
@@ -409,7 +281,6 @@
 					</div>
 					<div class="item-row">
 						<span class="sub-title">All sizes</span>
-						<span class="price">2.10</span>
 					</div>
 				</div>
 
@@ -420,18 +291,6 @@
 					<div class="item-row">
 						<span class="sub-title"><i>Ask for today's brew</i></span>
 					</div>
-					<div class="item-row">
-						<span class="sub-title">small</span>
-						<span class="price">2.00</span>
-					</div>
-					<div class="item-row">
-						<span class="sub-title">medium</span>
-						<span class="price">2.25</span>
-					</div>
-					<div class="item-row">
-						<span class="sub-title">large</span>
-						<span class="price">2.55</span>
-					</div>
 				</div>
 
 				<div class="item">
@@ -441,33 +300,14 @@
 					<div class="item-row">
 						<span class="sub-title"><i>Brewed coffee w/ steamed milk</i></span>
 					</div>
-					<div class="item-row">
-						<span class="sub-title">small</span>
-						<span class="price">2.75</span>
-					</div>
-					<div class="item-row">
-						<span class="sub-title">medium</span>
-						<span class="price">2.95</span>
-					</div>
-					<div class="item-row">
-						<span class="sub-title">large</span>
-						<span class="price">3.15</span>
-					</div>
 				</div>
 			</div>
 
-		</div> <!-- close row -->
-
 		<!-- Other Drinks and pastries -->
-		<div class="row expanded">
-			<div class="small-12">
-				<h4 class="menu-sub-heading" id="other-drinks">Other Drinks</h4>
-			</div>
-		</div>
 				<!-- Other Drinks 1st column =======================================-->
-		<div class="row expanded">
-			<div class="small-12 large-6 columns menu-column">
 
+			<div class="small-12 large-4 columns menu-column">
+				<h4 class="menu-sub-heading" id="other-drinks">Other Drinks</h4>
 				<div class="item">
 					<div class="item-row">
 						<span class="item-name">Smoothies</span>
@@ -484,14 +324,6 @@
 					<div class="item-row">
 						<span class="sub-title"><i>Blueberry, strawberry, banana, O.J. vanilla yogurt</i></span>
 					</div>
-					<div class="item-row">
-						<span class="sub-title">medium</span>
-						<span class="price">3.75</span>
-					</div>
-					<div class="item-row">
-						<span class="sub-title">large</span>
-						<span class="price">4.50</span>
-					</div>
 				</div>
 
 				<div class="item">
@@ -501,20 +333,7 @@
 					<div class="item-row">
 						<span class="sub-title"><i>Blended drinks with espresso and choice of white or dark chocolate</i></span>
 					</div>
-					<div class="item-row">
-						<span class="sub-title">medium</span>
-						<span class="price">3.75</span>
-					</div>
-					<div class="item-row">
-						<span class="sub-title">large</span>
-						<span class="price">4.50</span>
-					</div>
 				</div>
-
-
-			</div> <!-- close other drinks 1st column -->
-			<!-- Other drinks 2nd column -->
-			<div class="small-12 large-6 columns menu-column">
 
 				<div class="item">
 					<div class="item-row">
@@ -523,24 +342,11 @@
 					<div class="item-row">
 						<span class="sub-title"><i>Choice of cocoa w/ steamed milk</i></span>
 					</div>
-					<div class="item-row">
-						<span class="sub-title">small</span>
-						<span class="price">2.75</span>
-					</div>
-					<div class="item-row">
-						<span class="sub-title">medium</span>
-						<span class="price">3.00</span>
-					</div>
-					<div class="item-row">
-						<span class="sub-title">large</span>
-						<span class="price">3.25</span>
-					</div>
 				</div>
 
 				<div class="item">
 					<div class="item-row">
 						<span class="item-name">Italian Soda</span>
-						<span class="price">2.75</span>
 					</div>
 					<div class="item-row">
 						<span class="sub-title"><i>Sparkling water w/ flavored syrup</i></span>
@@ -550,13 +356,12 @@
 				<div class="item">
 					<div class="item-row">
 						<span class="item-name">French Cr&#233;me Soda</span>
-						<span class="price">2.75</span>
 					</div>
 					<div class="item-row">
 						<span class="sub-title"><i>Italian soda w/ a splash of cream</i></span>
 					</div>
 				</div>
 
-			</div> <!-- close other drinks second column -->
+			</div> <!-- close other column -->
 
 		</div> <!-- close other drinks row -->

--- a/views/styles/styles.css
+++ b/views/styles/styles.css
@@ -121,8 +121,8 @@
 .item-name {
 	color: red;
 }
-.price {
-	float: right
+#breakfast-subtitle {
+  margin-bottom: 4em; /* line up first items in breakfast and lunch */
 }
 #menu-pastries {
 	text-align: center;


### PR DESCRIPTION
Client doesn't want prices listed on menu. Remove prices from menu.
Adjust rows so they are not expanded (foundation grid).
Remove <br> from below breakfast section and replace with margin.
Left align the items and subheadings of the menu.
Add other drinks to main Drinks row.
Remove mention of price span in css.